### PR TITLE
Use the docsy theme iframe shortcode for the text messages page

### DIFF
--- a/content/text-messages/_index.md
+++ b/content/text-messages/_index.md
@@ -11,4 +11,4 @@ summary: ''
 This page shows all messages received by KN0CTJ's base station. It shows
 messages that have been received through MQTT or RF.
 
-<iframe src="https://meshmap.iowamesh.net/text-messages-embed.html" frameborder="0" style="width:100%;min-height:500px;"></iframe>
+{{<iframe src="https://meshmap.iowamesh.net/text-messages-embed.html" >}}


### PR DESCRIPTION
I found out that the Docsy theme has a [shortcode](https://www.docsy.dev/docs/adding-content/shortcodes/#iframe) for iframes. This pull request replaces the HTML code with the shortcode provided by the theme.